### PR TITLE
Use correct All Day iCal Syntax

### DIFF
--- a/CalDav/Event.cs
+++ b/CalDav/Event.cs
@@ -159,9 +159,17 @@ namespace CalDav {
 			wrtr.Property("CLASS", Class);
 			wrtr.Property("CREATED", Created);
 			wrtr.Property("DESCRIPTION", Description);
-			wrtr.Property("DTEND", IsAllDay ? (End ?? Start.Value).Date : End);
+			if (IsAllDay)
+			{
+				wrtr.Property("DTEND;VALUE=DATE", (End ?? Start.Value).ToString("yyyyMMdd"));
+				wrtr.Property("DTSTART;VALUE=DATE", (Start ?? End.Value).ToString("yyyyMMdd"));
+			}
+			else
+			{
+				wrtr.Property("DTEND", End);
+				wrtr.Property("DTSTART", Start);
+			}
 			wrtr.Property("DTSTAMP", DTSTAMP);
-			wrtr.Property("DTSTART", IsAllDay ? (Start ?? End.Value).Date : Start);
 			wrtr.Property("LAST-MODIFIED", LastModified);
 			wrtr.Property("LOCATION", Location);
 			wrtr.Property("ORGANIZER", Organizer);


### PR DESCRIPTION
Some CalDAV Server (e.g. Nextcloud) don't recognize an Event as an All-Day-Event if Start and End are 0h0m0s0ms. They need DTEND / DTSTART specified as a Date. This commit added this Feature to allow me to create All-Day Event in my Nextcloud.

P.S Sorry for the new Pull Request. I'm not that fluent with Git Pull Requests.