### PR TITLE
Allow \n in Property

### DIFF
--- a/CalDav/Common.cs
+++ b/CalDav/Common.cs
@@ -97,9 +97,9 @@ namespace CalDav {
 
 		private static string PropertyEncode(string value) {
 			return value
-				.Replace("\n", "\\n")
 				.Replace("\r", "\\r")
 				.Replace("\\", "\\\\")
+				.Replace("\n", "\\n")
 				.Replace(";", "\\;")
 				.Replace(",", "\\,")
 				.Replace("\r", "");


### PR DESCRIPTION
Prevoiusly `\n` was changed to `\\\\n`. If you used `\n` in your Event Description, it will be shown in your Calendar as `\n` not as a line Break. 
To be able to have a better Formatting in Event Description, I've changed the order of the `Replace ` Statements.
Now `\n` will be Formatted to `\\n` and will be shown as a line break in calendar.